### PR TITLE
Updated graddle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        //classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 


### PR DESCRIPTION
This will resolve the "No toolchains found in the NDK toolchains folder for ABI with prefix:" error on Android Studio 3.x.x